### PR TITLE
Ensure we own the /etc/logstash directory

### DIFF
--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -31,6 +31,7 @@
     owner: logstash
     group: logstash
   with_items:
+    - "{{ ls_yml['path.base'] }}"
     - "{{ ls_yml['path.data'] }}"
     - "{{ ls_yml['path.config'] }}"
     - "{{ ls_yml['path.logs'] }}"


### PR DESCRIPTION
Simple one-line change - easy to verify by checking the owner of `/etc/logstash` after running this