### PR TITLE
Services should restart instead of just start

### DIFF
--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -71,7 +71,7 @@
 - name: starting elasticsearch
   service:
     name: elasticsearch
-    state: started
+    state: restarted
     enabled: yes
   become: yes
   tags:

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -75,7 +75,7 @@
 - name: starting kibana
   service:
     name: kibana
-    state: started
+    state: restarted
     enabled: yes
   become: yes
   tags:

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -159,7 +159,7 @@
 - name: starting logstash
   service:
     name: logstash
-    state: started
+    state: restarted
     enabled: yes
   become: yes
   tags:


### PR DESCRIPTION
This is necessary for new provisions to take effect without manually restarting the service or rebuilding the entire machine.