### PR TITLE
Fix permission error surrounding kibana.pid

### DIFF
--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -18,6 +18,13 @@
   tags:
     - kibana
 
+- name: Change Kibana service to create /var/run/kibana.pid on start (bugfix)
+  lineinfile:
+    dest: /etc/init.d/kibana
+    line: '  touch $pidfile && chown $user:$group $pidfile'
+    insertafter: '^\s*# Setup any environmental stuff beforehand$'
+  become: yes
+
 - name: configuring kibana
   template:
     src: "{{ item.src }}"
@@ -65,14 +72,6 @@
 - name: Ensure correct permissions on kibana log
   file:
     path: "{{ kb_yml['logging.dest'] }}"
-    state: touch
-    owner: kibana
-    group: kibana
-  become: yes
-
-- name: creating pid file for kibana
-  file:
-    path: "{{ kb_yml['pid.file'] }}"
     state: touch
     owner: kibana
     group: kibana


### PR DESCRIPTION
Constant deletion/creation of this file was causing kibana to
crash in certain scenarios. This change alters the kibana service
to always ensure the pid file exists and is owned by kibana
every time the service starts (or is restarted).

Previously we attempted to address this during ansible provisioning.
This solution did not protect against all scenarios, however.
For example, rebooting the machine.

(Fixes #17)