### PR TITLE
Reload systemd configuration

### DIFF
--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -42,7 +42,11 @@
       ExecStartPre=/bin/chown kibana:kibana {{ kb_yml['pid.file'] }}
     insertafter: '^\[Service\]'
   become: yes
-  when: systemd_service
+  when: systemd_service.stat.exists
+
+- command: systemctl daemon-reload
+  become: yes
+  when: systemd_service.stat.exists
 
 - name: configuring kibana
   template:


### PR DESCRIPTION
The most recent deployment to Kibana showed a weakness in the previous commit.
Systemd requires you to manually run a "reload" command whenever you change up
the configuration. So after a server restart it would work fine, but for a live deployment
we need to ensure this happens.