### PR TITLE
Reference the list of installed plugins safely

### DIFF
--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -82,7 +82,7 @@
 
 - name: Uninstall plugins for upgrade
   command: "/usr/share/kibana/bin/kibana-plugin remove {{ item.split('@')[0] }}"
-  with_items: "{{ kb_installed_plugins.stdout_lines }}"
+  with_items: "{{ kb_installed_plugins.get('stdout_lines', None) }}"
   when: kb_install_plugins
   become: yes
 


### PR DESCRIPTION
This addresses a bug in older ansible versions where the step would
fail when the entire kibana installation was being skipped.

@dm00000 saw this fix in action