### PR TITLE
Properly check for the existence of systemd for kibana

### DIFF
--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -24,7 +24,7 @@
   register: etc_initd
 
 - stat:
-    path: /etc/systemd/system/kibana.service
+    path: /bin/systemctl
   register: systemd_service
 
 - lineinfile:
@@ -44,7 +44,9 @@
   become: yes
   when: systemd_service.stat.exists
 
-- command: systemctl daemon-reload
+- systemd:
+    name: kibana.service
+    daemon_reload: yes
   become: yes
   when: systemd_service.stat.exists
 


### PR DESCRIPTION
This was failing on hosts that did not have systemd installed.
This was due to the executable not being on the path when trying to
reload the systemd config files.

The biggest issue with this was it broke kibana installation on Ubuntu 14.