### PR TITLE
Only fill the header whitelist param when given

### DIFF
--- a/templates/kibana/kibana.yml.j2
+++ b/templates/kibana/kibana.yml.j2
@@ -31,7 +31,9 @@ elasticsearch.ssl.verify: {{ kb_yml['elasticsearch.ssl.verify'] }}
 
 elasticsearch.pingTimeout: {{ kb_yml['elasticsearch.pingTimeout'] }}
 elasticsearch.requestTimeout: {{ kb_yml['elasticsearch.requestTimeout'] }}
+{% if kb_yml['elasticsearch.requestHeadersWhitelist'] -%}
 elasticsearch.requestHeadersWhitelist: {{ kb_yml['elasticsearch.requestHeadersWhitelist'] }}
+{%- endif %}
 elasticsearch.customHeaders: {{ kb_yml['elasticsearch.customHeaders'] }}
 elasticsearch.shardTimeout: {{ kb_yml['elasticsearch.shardTimeout'] }}
 elasticsearch.startupTimeout: {{ kb_yml['elasticsearch.startupTimeout'] }}


### PR DESCRIPTION
We're changing this because X-Pack needed an Authorization header
when querying ES. But when the parameter was set to an empty array,
it wouldn't allow that header. So we omit the param unless
a value is specifically requested by the user.