### PR TITLE
Pulling Kibana role inline with ES instructions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -262,7 +262,7 @@ kb_yml:
   elasticsearch.shardTimeout: 0
   elasticsearch.startupTimeout: 5000
   pid.file: /var/run/kibana.pid
-  logging.dest: /var/log/kibana/kibana.yml
+  logging.dest: /var/log/kibana/kibana.log
   logging.silent: "false"
   logging.quiet: "false"
   logging.verbose: "false"

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -47,6 +47,7 @@
 - systemd:
     name: kibana.service
     daemon_reload: yes
+    enabled: yes
   become: yes
   when: systemd_service.stat.exists
 


### PR DESCRIPTION
Debian instructions have been updated a little. https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html
This change represents keepin' up with the times. 