### PR TITLE
set up the es role to download and install the bad mapping detector [DO NOT MERGE]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+*.DS_Store

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,12 @@
 # java stuff
 install_java: no
 
+# python stuff
+install_python: yes
+
+# git stuff
+install_git: yes
+
 
 # elastic general stuff
 elastic_major_version: "5.x"
@@ -17,6 +23,7 @@ es_version: ~
 es_heap_size: 512m
 es_plugins: []
 es_install_plugins: yes
+es_install_mapping_monitor: yes
 
 es_yml:
   cluster.name: elasticsearch
@@ -27,6 +34,7 @@ es_yml:
   node.attr.rack: ~
   path.data: /var/lib/elasticsearch
   path.logs: /var/log/elasticsearch
+  path.monitor: /etc/es-dynamic-mapping-detector
   bootstrap.memory_lock: 1
   network.host: 127.0.0.1
   http.port: 9200
@@ -34,6 +42,7 @@ es_yml:
   discovery.zen.minimum_master_nodes: ~
   gateway.recover_after_nodes: ~
   action.destructive_requires_name: 1
+  monitor.repo_path: "git@github.com:5thColumn/es-dynamic-mapping-detector.git"
 
 es_jvm_options:
   min_heap_size: "{{ es_heap_size }}"
@@ -63,11 +72,16 @@ ls_yml:
   pipeline.batch.delay: 5
   pipeline.unsafe_shutdown: "false"
   path.config: /etc/logstash/conf.d
+  path.geoipconfig: /etc/GeoIP.conf
   config.string: ""
   config.test_and_exit: "false"
   config.reload.automatic: "false"
   config.reload.interval: 3
   config.debug: "false"
+  config.geoipupdate_month: "*"
+  config.geoipupdate_weekday: "*"
+  config.geoipupdate_hour: "*"
+  config.geoipupdate_minute: "*"
   queue.type: memory
   path.queue: /var/lib/logstash/queue
   queue.page_capacity: 250mb

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,10 @@
 install_java: no
 
 # python stuff
-install_python: yes
+install_python: no
 
 # git stuff
-install_git: yes
+install_git: no
 
 
 # elastic general stuff
@@ -78,10 +78,6 @@ ls_yml:
   config.reload.automatic: "false"
   config.reload.interval: 3
   config.debug: "false"
-  config.geoipupdate_month: "*"
-  config.geoipupdate_weekday: "*"
-  config.geoipupdate_hour: "*"
-  config.geoipupdate_minute: "*"
   queue.type: memory
   path.queue: /var/lib/logstash/queue
   queue.page_capacity: 250mb

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -31,6 +31,16 @@
   tags:
     - elasticsearch
 
+- name: create monitoring app path
+  file:
+    path: "{{ es_yml['path.monitor'] }}"
+    state: directory
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
+  become: yes
+  when: es_install_mapping_monitor
+
+
 - name: configuring elasticsearch
   template:
     src: "{{ item.src }}"
@@ -55,6 +65,14 @@
   register: installed_plugin_list
   become: yes
   when: es_install_plugins
+
+- name: Get Monitoring App
+  git:
+    repo: "{{ es_yml['monitor.repo_path'] }}"
+    dest: "{{ es_yml['path.monitor'] }}"
+    version: dev
+    accept_hostkey: yes
+  when: es_install_mapping_monitor and install_python and install_git
 
 - name: Uninstall plugins that need to be updated
   command: /usr/share/elasticsearch/bin/elasticsearch-plugin remove {{ item }}

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -66,14 +66,6 @@
   become: yes
   when: es_install_plugins
 
-- name: Get Monitoring App
-  git:
-    repo: "{{ es_yml['monitor.repo_path'] }}"
-    dest: "{{ es_yml['path.monitor'] }}"
-    version: dev
-    accept_hostkey: yes
-  when: es_install_mapping_monitor and install_python and install_git
-
 - name: Uninstall plugins that need to be updated
   command: /usr/share/elasticsearch/bin/elasticsearch-plugin remove {{ item }}
   with_items: "{{ es_plugins }}"

--- a/tasks/es-monitor.yml
+++ b/tasks/es-monitor.yml
@@ -1,0 +1,14 @@
+- name: Get Monitoring App
+  git:
+    repo: "{{ es_yml['monitor.repo_path'] }}"
+    dest: "{{ es_yml['path.monitor'] }}"
+    version: dev
+    accept_hostkey: yes
+  when: es_install_mapping_monitor and install_python and install_git
+
+- name: installing python dependancies for monitoring app
+  pip:
+    requirements: "{{ es_yml['path.monitor'] }}/requirements.txt"
+    virtualenv: "{{ es_yml['path.monitor'] }}/venv"
+    virtualenv_python: python3.6
+  when: es_install_mapping_monitor and install_python and install_git

--- a/tasks/git.yml
+++ b/tasks/git.yml
@@ -1,0 +1,6 @@
+- name: installing git
+  apt:
+    name: git
+    state: latest
+    update_cache: yes
+  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,9 @@
 - include: python.yml
   when: install_python
 
+- include: es-monitor.yml
+  when: es_install_mapping_monitor
+
 - include: logstash.yml
   when: install_logstash
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,17 @@
 - include: java.yml
   when: install_java
 
+- include: git.yml
+  when: install_git
+
 - include: elastic-apt.yml
   when: install_elasticsearch or install_logstash or install_filebeat or install_kibana
 
 - include: elasticsearch.yml
   when: install_elasticsearch
+
+- include: python.yml
+  when: install_python
 
 - include: logstash.yml
   when: install_logstash

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -19,12 +19,6 @@
     executable: pip3
   become: yes
 
-- name: installing python dependancies
-  pip:
-    requirements: "{{ es_yml['path.monitor'] }}/requirements.txt"
-    virtualenv: "{{ es_yml['path.monitor'] }}/venv"
-    virtualenv_python: python3.6
-
 # sudo add-apt-repository ppa:fkrull/deadsnakes
 # sudo apt-get update
 # sudo apt-get install python3.6

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -19,6 +19,3 @@
     executable: pip3
   become: yes
 
-# sudo add-apt-repository ppa:fkrull/deadsnakes
-# sudo apt-get update
-# sudo apt-get install python3.6

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -1,0 +1,30 @@
+- name: download deadsnakes ppa
+  apt_repository:
+    repo: ppa:fkrull/deadsnakes
+  become: yes
+
+- name: installing python
+  apt:
+    name: "{{ item }}"
+    state: latest
+    update_cache: yes
+  with_items:
+    - python3.6
+    - python3-pip
+  become: yes
+
+- name: installing virtualenv
+  pip:
+    name: virtualenv
+    executable: pip3
+  become: yes
+
+- name: installing python dependancies
+  pip:
+    requirements: "{{ es_yml['path.monitor'] }}/requirements.txt"
+    virtualenv: "{{ es_yml['path.monitor'] }}/venv"
+    virtualenv_python: python3.6
+
+# sudo add-apt-repository ppa:fkrull/deadsnakes
+# sudo apt-get update
+# sudo apt-get install python3.6


### PR DESCRIPTION
DO NOT MERGE, WE NEED TO MAKE ANOTHER PR ONCE [this](https://github.com/5thColumn/ansible-role-elastic-stack-5.x/pull/27) IS MERGED
===

This update will pull/install the bad-mapping detector from our git.

Istruzioni
===
## Playbook and Vagrantfile

playbook.yml

```yaml
- hosts: all
  roles:
    - role: ansible-role-elastic-stack-5.x
      install_java: no
      install_elasticsearch: yes
      install_python: yes
      install_git: yes
```

vagrantfile

```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure('2') do |config|
  config.vm.box = 'ubuntu/trusty64'
  config.vm.hostname = 'elastic-stack'
  config.vm.network 'private_network', type: :dhcp

  config.vm.provider :virtualbox do |v, override|
    v.memory = 2048
    v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
    v.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
    v.customize ['modifyvm', :id, '--name', 'elastic-stack']
  end

  config.vm.provision :ansible do |ansible|
    ansible.playbook = 'playbook.yml'
  end
end
```

## Running detector from command line

1. After provisioning completes `vagrant ssh`
1. `cd /etc/es-dynamic-mapping-detector`
1. `source venv/bin/activate`
1. `python app.py`
1. Watch `#slack_bot_testing` channel in slack or just look at the log output