### PR TITLE
explicit comments, upgrade/downgrade problems

### DIFF
--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: installing elasticsearch
+- name: installing elasticsearch with version defined
   apt:
     name: elasticsearch={{ es_version }}
     state: present
@@ -9,7 +9,7 @@
   tags:
     - elasticsearch
 
-- name: installing elasticsearch
+- name: installing elasticsearch without version defined - default: latest
   apt:
     name: elasticsearch
     state: latest

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: installing kibana
+- name: installing kibana with version defined
   apt:
     name: kibana={{ kb_version }}
     state: present
@@ -9,7 +9,7 @@
   tags:
     - kibana
 
-- name: installing kibana
+- name: installing kibana without version defined - default: latest
   apt:
     name: kibana
     state: latest

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -6,19 +6,21 @@
     state: present
   become: yes
 
-- name: installing logstash
+- name: installing logstash with version defined
   apt:
     name: "logstash=1:{{ ls_version }}-1"
     state: present
+    force: yes
   become: yes
   when: ls_version is defined and ls_version
   tags:
     - logstash
 
-- name: installing logstash
+- name: installing logstash without version defined - default: latest
   apt:
     name: logstash
     state: latest
+    force: yes
   become: yes
   when: ls_version is undefined or not ls_version
   tags:


### PR DESCRIPTION
I added some comments to explicitly detail which install task was being triggered because I was having issues tacking down a versioning issue in Logstash. 

In completing this work, I discovered that when downgrading logstash without force: yes, it would throw an error

```
atal: [10.9.13.42]: FAILED! => {"cache_update_time": 1493241248, "cache_updated": false, "changed": false, "failed": true, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'logstash=1:5.2.0-1'' failed: E: Packages were downgraded and -y was used without --allow-downgrades.\n", "stderr": "E: Packages were downgraded and -y was used without --allow-downgrades.\n", "stderr_lines": ["E: Packages were downgraded and -y was used without --allow-downgrades."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages will be DOWNGRADED:\n  logstash\n0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 30 not upgraded.\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following packages will be DOWNGRADED:", "  logstash", "0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 30 not upgraded."]}
```

To test this, you must install logstash v5.3.1 then reinstall/downgrade logstash v5.2.0

1. Checkout the `dft-x-pack` branch in 5c-roles (if it's not already merged into the Dev branch). 
It has the ES version in the [dft:vars] section of the inventory file. 

1. dft-logstash is currently not being used. C+P the following command into the terminal `python3 $(which ansible-playbook) -i inventory playbooks/dft-logstash.yml`

1. If you feel inclined to do so you can ssh into the box (`ssh ubuntu@10.9.13.42`) and type `sudo /usr/chare/logstash/bin/logstash --version` to confirm the version. 

Ultimately a successful test would not be throwing any errors. 