### PR TITLE
Allow users to specify extra ES config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,7 @@ es_yml:
   discovery.zen.minimum_master_nodes: ~
   gateway.recover_after_nodes: ~
   action.destructive_requires_name: 1
+  extra_config: ~
 
 es_jvm_options:
   min_heap_size: "{{ es_heap_size }}"

--- a/templates/elasticsearch/elasticsearch.yml.j2
+++ b/templates/elasticsearch/elasticsearch.yml.j2
@@ -43,3 +43,8 @@ gateway.recover_after_nodes: {{ es_yml['gateway.recover_after_nodes'] }}
 
 # ---------------------------------- Various -----------------------------------
 action.destructive_requires_name: {{ es_yml['action.destructive_requires_name'] }}
+
+{% if es_yml['extra_config'] %}
+# ------------------------------ Miscellaneous ---------------------------------
+{{ es_yml['extra_config'] | to_yaml }}
+{% endif %}


### PR DESCRIPTION
This comes in handy for addons, such as x-pack.
Just supply your YAML config object directly into es_yml.extra_config.
It will appear at the bottom of elasticsearch.yml